### PR TITLE
fixed the alignment of zeus grid

### DIFF
--- a/frontend/src/components/Pages/Home/index.js
+++ b/frontend/src/components/Pages/Home/index.js
@@ -88,9 +88,6 @@ const Home = () => {
                 </Grid>
                 {
                     layouts.filter((item) => item !== layout).map((restLayout) => {
-                        {console.log('====================================');
-                        console.log(restLayout);
-                        console.log('====================================');}
                         return (
                             <Grid key={restLayout} item xs={12} sm={12} md={6}>
                                 <TemplateCard theme={theme} animation={animation} layout={restLayout} font={font} />

--- a/frontend/src/components/Pages/Home/index.js
+++ b/frontend/src/components/Pages/Home/index.js
@@ -88,6 +88,9 @@ const Home = () => {
                 </Grid>
                 {
                     layouts.filter((item) => item !== layout).map((restLayout) => {
+                        {console.log('====================================');
+                        console.log(restLayout);
+                        console.log('====================================');}
                         return (
                             <Grid key={restLayout} item xs={12} sm={12} md={6}>
                                 <TemplateCard theme={theme} animation={animation} layout={restLayout} font={font} />

--- a/frontend/src/components/organisms/TemplateCard/index.js
+++ b/frontend/src/components/organisms/TemplateCard/index.js
@@ -62,7 +62,7 @@ const TemplateCard = (props) => {
   }, [quoteUrl]);
 
   return (
-    <Paper style={{ padding: "10px" }}>
+    <Paper style={{ padding: "10px" ,width: "100%", height: "100%"}}>
       <div style={{ textAlign: "center" }}>
         <img
           src={url}


### PR DESCRIPTION
With regards to the issue #128 , Added a styling option in the template card's paper tag using in-line styling, giving width and height as 100% of scaling, giving a certain uniformity.

Screenshots:
**Before**
![image](https://user-images.githubusercontent.com/56084650/116184856-2aa1f480-a73e-11eb-8963-a474aad9febc.png)

**After**
![image](https://user-images.githubusercontent.com/56084650/116184777-0d6d2600-a73e-11eb-8631-8ac1a2604409.png)
