### PR TITLE
Readjustment of socrates layout

### DIFF
--- a/src/layouts/layout.js
+++ b/src/layouts/layout.js
@@ -61,30 +61,30 @@ const layouts = {
                 } 
                 ${template.animation.keyframes}
                 .square-brackets-quote blockquote {
-                    border:solid 1em #${
-                      template.theme.bg_color === "fffefe"
-                        ? "ccc"
-                        : template.theme.bg_color
-                    };
-                    background: #fff;
+                    background: #${template.theme.bg_color};
+                    color: #${template.theme.quote_color};
                     display:inline-block;
                     margin:0;
-                    padding:1em;
+                    padding:2em;
                     position:relative;
                     font-size:15px;
                     
                 }
                  .square-brackets-quote blockquote::before {
-                    background-color: #fff;
-                    bottom: -1em;
-                    content: "";
-                    left: 2em;
+                    --border: #${template.theme.author_color};
                     position: absolute;
-                    right: 2em;
-                    top: -1em;
+                    content: "";
+                    top: 0;
+                    bottom: 0;
+                    right: 0;
+                    left: 0;
+                    background-image: linear-gradient(var(--border), var(--border)), linear-gradient(var(--border), var(--border)), linear-gradient(var(--border), var(--border)), linear-gradient(var(--border), var(--border)), linear-gradient(var(--border), var(--border)), linear-gradient(var(--border), var(--border));
+                    background-repeat: no-repeat;
+                    background-size: 3em 1em, 1em 100%, 3em 1em, 3em 1em, 1em 100%, 3em 1em;
+                    background-position: left bottom, left top, left top, right bottom, right top, right top;
                     }
                 .square-brackets-quote cite {
-                    color:#757575;
+                    color: #${template.theme.author_color};
                     display: block;
                     font-size:small;
                     font-style: normal;


### PR DESCRIPTION
Hi, i was messing around and i realized that socrates and samuel layouts don't effected by themes (background and letter colors don't change as the theme changes), also i took a look regarding to #124 and i was not able to implement gradient background to these layouts. So i readjust socrates layout and now it's easier to implement gradient and image backgrounds to this layout also it's compatible with themes. Here is some examples:

![Screenshot from 2021-10-03 11-15-55](https://user-images.githubusercontent.com/27775083/135746714-40d19a20-1695-4e92-bffe-012d97d279bb.png)
![Screenshot from 2021-10-03 11-35-04](https://user-images.githubusercontent.com/27775083/135746720-e9074617-8d2d-421a-b7d5-3e13dfc129a3.png)
![Screenshot from 2021-10-03 11-35-12](https://user-images.githubusercontent.com/27775083/135746724-010c1927-fb5f-47d0-aac3-a5021b7c8d26.png)
![Screenshot from 2021-10-03 11-55-05](https://user-images.githubusercontent.com/27775083/135746725-6464e7c6-e149-4a81-817a-b560cdd49dcb.png)

