### PR TITLE
Hotfix - Renamed createMuiTheme import into createTheme

### DIFF
--- a/frontend/src/components/Dashboard/index.js
+++ b/frontend/src/components/Dashboard/index.js
@@ -6,7 +6,7 @@ import CssBaseline from '@material-ui/core/CssBaseline';
 import useScrollTrigger from '@material-ui/core/useScrollTrigger';
 import Container from '@material-ui/core/Container';
 import { IconButton, Paper } from '@material-ui/core';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import { dashConstants } from '../../config/constants';
 import { LightTheme, DarkTheme } from '../../util/themes/GlobalThemes';
 import { getAppBarStyles } from '../../util/styles/componentStyles';
@@ -33,8 +33,8 @@ function ElevationScroll(props) {
 function Dashboard(props) {
     const [isDark, setIsDark] = useState(false);
     const theme = isDark
-        ? createMuiTheme(DarkTheme)
-        : createMuiTheme(LightTheme);
+        ? createTheme(DarkTheme)
+        : createTheme(LightTheme);
     const classes = getAppBarStyles();
 
     function handleThemeChange() {


### PR DESCRIPTION
Hello everyone, this is my first pull request on an open source repository. I want to contribute starting from easier tasks and gradually increase the difficulty to learn something new.

This PR solves the error in console caused by deprecated import because in Material-UI the createMuiTheme function was renamed to createTheme.

![WhatsApp Image 2023-10-01 at 00 59 31](https://github.com/shravan20/github-readme-quotes/assets/20328554/9db7d02f-679f-4ff0-a55d-c1ac6ca8b9e1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Updated the `createMuiTheme` function to `createTheme` in the Dashboard component. This change ensures compatibility with the latest version of Material-UI, providing a smoother and more reliable user interface experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->