### PR TITLE
feat: Add Unsplash Background Support (#239)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 PORT = <PORT_NUMBER>
 SERVICE_URL = <URL_FETCHING_RANDOM_QUOTES>
-
+UNSPLASH_ACCESS_KEY = <YOUR_UNSPLASH_ACCESS_KEY>
+UNSPLASH_SECRET_KEY = <YOUR_UNSPLASH_SECRET_KEY>
 # In the same folder create .env file, with same key and add your custom values to it.

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 PORT = <PORT_NUMBER>
 SERVICE_URL = <URL_FETCHING_RANDOM_QUOTES>
+# Access key for Unsplash API (Get it from: https://unsplash.com/developers)
 UNSPLASH_ACCESS_KEY = <YOUR_UNSPLASH_ACCESS_KEY>
-UNSPLASH_SECRET_KEY = <YOUR_UNSPLASH_SECRET_KEY>
 # In the same folder create .env file, with same key and add your custom values to it.

--- a/README.md
+++ b/README.md
@@ -257,6 +257,20 @@ Use `?borderColor=COLOR` paramater as shown below
 
 ---
 
+- ### Unsplash Background
+You can fetch random background images from [Unsplash](https://unsplash.com/) by specifying two parameters:
+
+1. `bgSource=unsplash`
+2. `unsplashQuery=ANY_KEYWORD` (optional)
+
+```md
+![Quote](https://github-readme-quotes-bay.vercel.app/quote?bgSource=unsplash&unsplashQuery=nature)
+```
+
+![Quote](https://github-readme-quotes-bay.vercel.app/quote?bgSource=unsplash&unsplashQuery=nature)
+
+---
+
 ## Swagger Docs
 
 To view Swagger docs, run `npm start` and open ![localhost:3002/api-docs](localhost:3002/api-docs).

--- a/frontend/src/components/Pages/Home/index.js
+++ b/frontend/src/components/Pages/Home/index.js
@@ -24,6 +24,9 @@ const Home = () => {
     const [bgColor, setBgColor] = useState(null);
     const [borderColor, setBorderColor] = useState(null);
     const [quoteType, setQuoteType] = useState("random");
+    const [bgSource, setBgSource] = useState(null);
+    const [unsplashQuery, setUnsplashQuery] = useState("");
+
 
     const classes = useStyles();
 
@@ -158,11 +161,35 @@ const Home = () => {
                     />
                 </Grid>
 
+                <Grid item xs={12} sm={6} lg={3}>
+                    <Autocomplete
+                        id="bg-source"
+                        options={['unsplash']}
+                        value={bgSource}
+                        style={{ width: 300, margin: '0 auto' }}
+                        onChange={(_event, newValue) => {
+                            setBgSource(newValue);
+                        }}
+                        renderInput={(params) => <TextField {...params} label="Background Source" placeholder="Select 'unsplash' or leave empty" variant="outlined" />}
+                    />
+                </Grid>
+
+                <Grid item xs={12} sm={6} lg={3}>
+                    <TextField
+                        label="Unsplash query"
+                        variant="outlined"
+                        value={unsplashQuery}
+                        style={{ width: 300, margin: '0 auto' }}
+                        onChange={(event) => setUnsplashQuery(event.target.value)}
+                        disabled={bgSource !== 'unsplash'}
+                    />
+                </Grid>
+
             </Grid>
 
             <Grid container spacing={4}>
                 <Grid item xs={12} style={{ marginTop: '20px' }}>
-                    <TemplateCard theme={theme} animation={animation} layout={layout} font={font} fontColor={fontColor} bgColor={bgColor} borderColor={borderColor} quoteType={quoteType} />
+                    <TemplateCard theme={theme} animation={animation} layout={layout} font={font} fontColor={fontColor} bgColor={bgColor} borderColor={borderColor} quoteType={quoteType} bgSource={bgSource} unsplashQuery={unsplashQuery} />
                 </Grid>
                 <Grid item xs={12}>
                     <Typography align="center">Other layouts</Typography>
@@ -171,7 +198,7 @@ const Home = () => {
                     layouts.filter((item) => item !== layout).map((restLayout) => {
                         return (
                             <Grid key={restLayout} item xs={12} sm={12} md={6}>
-                                <TemplateCard theme={theme} animation={animation} layout={restLayout} font={font} fontColor={fontColor} bgColor={bgColor} borderColor={borderColor} quoteType={quoteType} />
+                                <TemplateCard theme={theme} animation={animation} layout={restLayout} font={font} fontColor={fontColor} bgColor={bgColor} borderColor={borderColor} quoteType={quoteType} bgSource={bgSource} unsplashQuery={unsplashQuery} />
                             </Grid>
                         )
                     })

--- a/frontend/src/components/organisms/TemplateCard/index.js
+++ b/frontend/src/components/organisms/TemplateCard/index.js
@@ -78,6 +78,8 @@ const TemplateCard = (props) => {
     ...(props.bgColor && { bgColor: props.bgColor }),
     ...(props.fontColor && { fontColor: props.fontColor }),
     ...(isLayoutDefault && props.borderColor && { borderColor }),
+    ...(props.bgSource === 'unsplash' && { bgSource: 'unsplash' }),
+    ...(props.bgSource === 'unsplash' && props.unsplashQuery && { unsplashQuery: props.unsplashQuery }),
   });
   const quoteUrl = `${originUrl}/quote?${params.toString()}`;
 

--- a/src/api/controllers/quotesController.js
+++ b/src/api/controllers/quotesController.js
@@ -33,6 +33,8 @@ const quoteController = async (req, res, next) => {
     let font = fonts[req.query.font] ? fonts[req.query.font] : fonts['default'];
 
     let quoteType = req.query.quoteType || '';
+    let bgSource = req.query.bgSource || '';
+    let unsplashQuery = req.query.unsplashQuery || '';
 
     let quoteObject = {
       theme,
@@ -42,7 +44,9 @@ const quoteController = async (req, res, next) => {
       quoteCategory,
       font,
       quoteType,
-      borderColor
+      borderColor,
+      bgSource,
+      unsplashQuery
     }
 
     let svgResponse = await quoteService.getQuote(quoteObject);

--- a/src/api/controllers/quotesController.js
+++ b/src/api/controllers/quotesController.js
@@ -14,7 +14,10 @@ const quoteController = async (req, res, next) => {
       theme.quote_color = fontColor;
     }
     const bgColor = req.query.bgColor;
-    if (bgColor) {
+    const bgSource = req.query.bgSource || '';
+    if (bgSource === 'unsplash') {
+      theme.bg_color = 'transparent';
+    } else if (bgColor) {
       theme.bg_color = bgColor;
     }
 
@@ -33,7 +36,6 @@ const quoteController = async (req, res, next) => {
     let font = fonts[req.query.font] ? fonts[req.query.font] : fonts['default'];
 
     let quoteType = req.query.quoteType || '';
-    let bgSource = req.query.bgSource || '';
     let unsplashQuery = req.query.unsplashQuery || '';
 
     let quoteObject = {

--- a/src/api/services/quotesService.js
+++ b/src/api/services/quotesService.js
@@ -69,7 +69,24 @@ module.exports = {
   getQuote,
 };
 
+const unsplashCache = new Map();
+
 async function getUnsplashImage(query) {
+  const now = Date.now();
+  // 10-minute cache (details: PR #336#issuecomment-2662258916)
+  const CACHE_DURATION = 10 * 60 * 1000;
+
+  const cached = unsplashCache.get(query);
+  if (cached && (now - cached.timestamp < CACHE_DURATION)) {
+    return cached.data;
+  }
+
+  const imageUrl = await fetchUnsplash(query);
+  unsplashCache.set(query, { data: imageUrl, timestamp: now });
+  return imageUrl;
+}
+
+async function fetchUnsplash(query) {
   const accessKey = process.env.UNSPLASH_ACCESS_KEY;
   if (!accessKey) {
     console.error('Unsplash access key not configured');

--- a/src/api/services/quotesService.js
+++ b/src/api/services/quotesService.js
@@ -56,6 +56,7 @@ const getQuote = async (quoteObj) => {
     template.setAnimation(animation);
     template.setBorderColor(borderColor);
     template.setLayout(layout);
+    template.bgImage = bgImageUrl;
 
     let svg = cardTemplate.generateTemplate(template);
     return svg;

--- a/src/api/services/quotesService.js
+++ b/src/api/services/quotesService.js
@@ -15,7 +15,7 @@ getQuoteIndex = (apiResponseLength, quoteType) => {
 const getQuote = async (quoteObj) => {
 
   try {
-    let { theme, animation, layout, quotesUrl, quoteCategory, font, quoteType, borderColor } = quoteObj;
+    let { theme, animation, layout, quotesUrl, quoteCategory, font, quoteType, borderColor, bgSource, unsplashQuery } = quoteObj;
     let apiResponse;
     let { customQuotesUrl, isValidUrl } = await getValidUrl(quotesUrl);
     let isCustomQuote = false;
@@ -44,6 +44,11 @@ const getQuote = async (quoteObj) => {
       apiResponse = await requestApi(url);
     }
 
+    let bgImageUrl = "";
+    if (bgSource === "unsplash") {
+      bgImageUrl = await getUnsplashImage(unsplashQuery || 'random');
+    }
+
     const template = new Template();
     template.setTheme(theme);
     template.setData(isCustomQuote ? apiResponse : apiResponse[Math.floor(getQuoteIndex(apiResponse.length, quoteType))]);
@@ -62,3 +67,20 @@ const getQuote = async (quoteObj) => {
 module.exports = {
   getQuote,
 };
+
+async function getUnsplashImage(query) {
+  const accessKey = process.env.UNSPLASH_ACCESS_KEY;
+  const unsplashUrl = `https://api.unsplash.com/photos/random?query=${encodeURIComponent(query)}&client_id=${accessKey}`;
+
+  try {
+    const response = await requestApi(unsplashUrl);
+    if (response && response.urls && response.urls.regular) {
+      return response.urls.regular;
+    } else {
+      return '';
+    }
+  } catch (err) {
+    console.error('Error fetching Unsplash image:', err);
+    return '';
+  }
+}

--- a/src/api/services/quotesService.js
+++ b/src/api/services/quotesService.js
@@ -71,6 +71,11 @@ module.exports = {
 
 async function getUnsplashImage(query) {
   const accessKey = process.env.UNSPLASH_ACCESS_KEY;
+  if (!accessKey) {
+    console.error('Unsplash access key not configured');
+    return '';
+  }
+
   const unsplashUrl = `https://api.unsplash.com/photos/random?query=${encodeURIComponent(query)}&client_id=${accessKey}`;
 
   try {

--- a/src/api/services/quotesService.js
+++ b/src/api/services/quotesService.js
@@ -80,11 +80,7 @@ async function getUnsplashImage(query) {
 
   try {
     const response = await requestApi(unsplashUrl);
-    if (response && response.urls && response.urls.regular) {
-      return response.urls.regular;
-    } else {
-      return '';
-    }
+    return response?.urls?.regular ?? '';
   } catch (err) {
     console.error('Error fetching Unsplash image:', err);
     return '';

--- a/src/common/getTemplate.js
+++ b/src/common/getTemplate.js
@@ -1,4 +1,14 @@
 const getTemplate = (template) => {
+  const escapeHtml = require('escape-html');
+  const safeUrl = escapeHtml(template.bgImage);
+  const backgroundImageLayer = safeUrl
+    ? `<image href="${safeUrl}"
+        x="0" y="0"
+        width="700"
+        height="${parseInt(template.height)}"
+        preserveAspectRatio="xMidYMid slice" />`
+    : '';
+
   return `
     <svg width="700px" height="${parseInt(
       template.height
@@ -11,6 +21,7 @@ const getTemplate = (template) => {
       }
       </style>
     </defs>
+    ${backgroundImageLayer}
     <foreignObject width="100%" height="100%">
         <div xmlns="http://www.w3.org/1999/xhtml">
             <style>


### PR DESCRIPTION
### Overview
This PR introduces an option to fetch random background images from Unsplash, allowing users to customize the quote's backdrop for a more visually appealing design.

### Changes
- Implemented a new feature that uses `bgSource=unsplash` and an optional `unsplashQuery` parameter to retrieve background images.
- Updated README.md with usage instructions and a sample code snippet for Unsplash backgrounds.
- If `bgSource=unsplash` is detected, the default background color becomes transparent.

### How to Test

1. Add your [Unsplash API](https://unsplash.com/developers) Access Key to the `.env` file as `UNSPLASH_ACCESS_KEY`.
2. Run `npm start` to launch the server.
3. Navigate to `http://localhost:3004/quote?bgSource=unsplash&unsplashQuery=nature.`

**Below is an example screenshot showing the feature in action:**
![スクリーンショット 2025-02-17 3 15 02](https://github.com/user-attachments/assets/7fb9f18b-3a3b-4949-98fe-ab3152b3eae7)

### Additional Considerations

- There is a readability issue when the chosen background image has colors similar to the text color. Because the final background is unknown beforehand, we might need a semi-transparent overlay behind the text or add a text outline/drop-shadow to improve legibility. Suggestions or feedback on how to address this are welcome!

- Currently, when bgSource=unsplash is set, bgColor is automatically overridden to transparent. However, if the Unsplash API fails or returns a "Rate Limit Exceeded" error, the background image may not load. Should we maintain a non-transparent fallback color in such cases instead of forcing transparency? Feedback on this approach would be appreciated.

### Sample Images 

```
http://localhost:3004/quote?bgSource=unsplash&unsplashQuery=morning&fontColor=%23000000
```
<img width="768" alt="スクリーンショット 2025-02-17 10 37 45" src="https://github.com/user-attachments/assets/b319ee06-42e0-4323-b6de-f0b3a00ac215" />

-----
```
http://localhost:3004/quote?bgSource=unsplash&unsplashQuery=tech&fontColor=%23FFFFFF
```
<img width="768" alt="スクリーンショット 2025-02-17 10 34 15" src="https://github.com/user-attachments/assets/d2c9d47e-6469-4ec4-9c30-0cb9755a3aa5" />

-----
```
http://localhost:3004/quote?bgSource=unsplash&unsplashQuery=night&fontColor=%23FFFFFF
```
<img width="770" alt="スクリーンショット 2025-02-17 10 26 33" src="https://github.com/user-attachments/assets/edbd2125-c4a9-44cf-9230-5ea9492be9d8" />

-----
```
http://localhost:3004/quote?bgSource=unsplash&unsplashQuery=sea&fontColor=%23FFFFFF
```
<img width="768" alt="スクリーンショット 2025-02-17 10 31 14" src="https://github.com/user-attachments/assets/78163a68-829d-479c-b696-ede8f61489fc" />


Closes #239

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced Unsplash background support, enabling you to enhance quote images with dynamic visuals. Now, by specifying the new parameters, you can request random or keyword-based backgrounds from Unsplash, adding a fresh look to your quotes.

- **Documentation**
  - Updated documentation with a dedicated section on Unsplash backgrounds, providing clear instructions and example snippets to help you customize your quotes effortlessly.

- **Improvements**
  - Enhanced background handling logic to support dynamic background colors based on the source specified.
  - Added functionality to sanitize background image URLs for improved security and reliability.
  - Introduced new state management in the Home component to allow user selection of background source and query.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->