### PR TITLE
fix: large fonts cause image bottom clipping (#338).

### DIFF
--- a/src/models/Template.js
+++ b/src/models/Template.js
@@ -43,7 +43,7 @@ class Template {
     let lines;
     if (this.layout !== layouts["zues"]) {
       lines = Math.floor(length / 64);
-      this.height = lines > 2 ? (lines - 2) * 22 + 173 : 173;
+      this.height = lines > 2 ? (lines - 2) * 25 + 195 : 195;
     } else {
       lines = Math.floor(length / 62);
       this.height = lines * 18 + 198;


### PR DESCRIPTION
## Problem
Image bottom gets clipped when using larger fonts like PixelifySans with multi-line quotes. The `calculateHeight()` function uses fixed values optimized for default fonts, causing insufficient height allocation for larger fonts.

## Root Cause
- PixelifySans characters are wider, so fewer characters fit per line than the assumed 64 chars/line
- Function miscounts lines (calculates 1 line when actually 2 lines)
- Fixed 22px line increment insufficient for larger fonts

## Solution
Increased height values in `calculateHeight()` function:
- Base height: 173px → 195px (handles line counting errors)
- Line increment: 22px → 25px (accommodates larger font spacing)

```javascript
// Before
this.height = lines > 2 ? (lines - 2) * 22 + 173 : 173;

// After  
this.height = lines > 2 ? (lines - 2) * 25 + 195 : 195;

```

Closes #338

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layout rendering by adjusting height calculations for templates, resulting in better visual consistency for layouts other than "zues".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->