### PR TITLE
docs: clarify custom font usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,18 @@ Use `?font=FONT_NAME` parameter as shown below
 ![Quote](https://github-readme-quotes-bay.vercel.app/quote?font=Redressed)
 ```
 
+The font parameter selects one of the fonts bundled with this project. Use the
+font key as it appears in the list below. Font keys are case-sensitive, and you
+can combine them with the other quote parameters by adding `&font=FONT_NAME`.
+
+```md
+![Quote](https://github-readme-quotes-bay.vercel.app/quote?theme=dark&layout=socrates&font=gabrielle)
+```
+
+#### Available Fonts
+
+default, gabrielle, Redressed, Calligraffitti, Architect, PixelifySans
+
 #### Font 1 (Default)
 
 ![Quote](https://github-readme-quotes-bay.vercel.app/quote?theme=dark)
@@ -173,6 +185,11 @@ Use `?font=FONT_NAME` parameter as shown below
 <!-- Scrnshot of quote in different fonts -->
 
 You can explore different fonts [here](./src/fonts/README.md).
+
+To contribute another font, add its font-face data to
+[`src/fonts/fonts.js`](./src/fonts/fonts.js), document the new parameter value in
+[`src/fonts/README.md`](./src/fonts/README.md), and include a preview link in
+this section.
 
 <b>Feel free to contribute different fonts.</b>
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,24 @@ can combine them with the other quote parameters by adding `&font=FONT_NAME`.
 ![Quote](https://github-readme-quotes-bay.vercel.app/quote?theme=dark&layout=socrates&font=gabrielle)
 ```
 
+The quote endpoint does not load arbitrary remote font URLs from the query
+string. To use a custom font, add it to the bundled font list first, then pass
+its registered key with `font`. For example, a contributor can start from a
+Google Fonts CSS URL such as:
+
+```txt
+https://fonts.googleapis.com/css2?family=Redressed
+```
+
+Convert the font file referenced by that CSS into embedded base64 font data,
+add it to [`src/fonts/fonts.js`](./src/fonts/fonts.js), and document the new
+key in [`src/fonts/README.md`](./src/fonts/README.md). After it is registered,
+users can preview it with a normal quote URL:
+
+```md
+![Quote](https://github-readme-quotes-bay.vercel.app/quote?theme=dark&font=Redressed)
+```
+
 #### Available Fonts
 
 default, gabrielle, Redressed, Calligraffitti, Architect, PixelifySans
@@ -186,7 +204,8 @@ default, gabrielle, Redressed, Calligraffitti, Architect, PixelifySans
 
 You can explore different fonts [here](./src/fonts/README.md).
 
-To contribute another font, add its font-face data to
+To contribute another font, use its source CSS URL to find the font file,
+convert that file into embedded base64 font data, add the font-face data to
 [`src/fonts/fonts.js`](./src/fonts/fonts.js), document the new parameter value in
 [`src/fonts/README.md`](./src/fonts/README.md), and include a preview link in
 this section.

--- a/src/fonts/README.md
+++ b/src/fonts/README.md
@@ -2,11 +2,30 @@
 
 You can add fonts to your templates without any manual customization.
 
-Use `?font=FONT_NAME` parameter like so :-
+Use the `?font=FONT_NAME` parameter with one of the bundled font names:
+
+- `default`
+- `gabrielle`
+- `Redressed`
+- `Calligraffitti`
+- `Architect`
+- `PixelifySans`
+
+For example:
 
 ```md
 ![Quote](https://github-readme-quotes-bay.vercel.app/quote?font=Redressed)
 ```
+
+When combining a font with other options, append it with `&font=FONT_NAME`:
+
+```md
+![Quote](https://github-readme-quotes-bay.vercel.app/quote?theme=dark&layout=socrates&font=gabrielle)
+```
+
+To add another font, register it in [`fonts.js`](./fonts.js), use a stable
+parameter key, and add a preview example below so README users can copy the
+correct value.
 
 ### Fonts
 
@@ -16,12 +35,20 @@ Use `?font=FONT_NAME` parameter like so :-
 
 - Gabrielle <br>
 
-![Quote](https://github-readme-quotes-bay.vercel.app/quote?theme=dark&font=Gabrielle)
+![Quote](https://github-readme-quotes-bay.vercel.app/quote?theme=dark&font=gabrielle)
 
 - Redressed <br>
 
 ![Quote](https://github-readme-quotes-bay.vercel.app/quote?theme=dark&font=Redressed)
 
+- Calligraffitti <br>
+
+![Quote](https://github-readme-quotes-bay.vercel.app/quote?theme=dark&font=Calligraffitti)
+
 - Architect <br>
 
 ![Quote](https://github-readme-quotes-bay.vercel.app/quote?theme=dark&font=Architect)
+
+- PixelifySans <br>
+
+![Quote](https://github-readme-quotes-bay.vercel.app/quote?theme=dark&font=PixelifySans)

--- a/src/fonts/README.md
+++ b/src/fonts/README.md
@@ -23,9 +23,17 @@ When combining a font with other options, append it with `&font=FONT_NAME`:
 ![Quote](https://github-readme-quotes-bay.vercel.app/quote?theme=dark&layout=socrates&font=gabrielle)
 ```
 
-To add another font, register it in [`fonts.js`](./fonts.js), use a stable
-parameter key, and add a preview example below so README users can copy the
-correct value.
+The endpoint accepts registered font keys, not arbitrary remote font URLs in
+the query string. To add another font, start from a source CSS URL such as a
+Google Fonts URL:
+
+```txt
+https://fonts.googleapis.com/css2?family=Redressed
+```
+
+Use that CSS to find the font file, convert the font file to embedded base64
+font data, register it in [`fonts.js`](./fonts.js), use a stable parameter key,
+and add a preview example below so README users can copy the correct value.
 
 ### Fonts
 


### PR DESCRIPTION
## Summary
- clarifies that `font` selects bundled font keys and that the keys are case-sensitive
- documents every current font key exported by `src/fonts/fonts.js`
- adds combined query examples and contribution notes for adding future fonts

Fixes #119.

## Checks
- `node` docs coverage check against `src/fonts/fonts.js`
- `git diff --check`

Optional: if this saves you time and you want to settle it as a small paid docs microfix, $5 works here: https://nicdunz.gumroad.com/l/tiny-codex-teardown-direct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the font query parameter: case-sensitive bundled keys, how to combine with other query options, and example usage.
  * Added an "Available Fonts" list with standardized preview links and new bundled previews.
  * Added contributor guidance describing how to add and register new bundled fonts and include preview examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zhravan/github-readme-quotes/pull/367?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->